### PR TITLE
Avance en confirmación de cita

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
+## [1.5.0] - 2026-06-16 (Trabajando)
+
+### ✨ Mejoras
+
+- Nuevo _endpoint_ `confirmar_cita`. Al recibir el número de código de asistencia, se marca la asistencia y se genera un turno en el sistema de turnos, y se regresa toda esa información como resultado de la petición. Si ya existe la asistencia y el turno, solo regresar la información.
+
+
 ## [1.4.2] - 2026-06-11
 
 ### 🛠️ Cambios

--- a/pjecz_casiopea_api_key/main.py
+++ b/pjecz_casiopea_api_key/main.py
@@ -37,7 +37,7 @@ app = FastAPI(
     description="API con autentificación del sistema de citas.",
     docs_url="/docs",
     redoc_url=None,
-    version="1.4.2",
+    version="1.5.0",
 )
 
 # CORSMiddleware

--- a/pjecz_casiopea_api_key/models/cit_citas.py
+++ b/pjecz_casiopea_api_key/models/cit_citas.py
@@ -52,6 +52,8 @@ class CitCita(Base, UniversalMixin):
     codigo_acceso_url: Mapped[Optional[str]] = mapped_column(String(512))
     codigo_barras: Mapped[Optional[str]] = mapped_column(String(13))
     codigo_barras_url: Mapped[Optional[str]] = mapped_column(String(512))
+    turno_id: Mapped[Optional[int]]
+    turno: Mapped[Optional[str]] = mapped_column(String(16))
 
     @property
     def codigo_acceso_imagen_base64(self):

--- a/pjecz_casiopea_api_key/routers/cit_citas.py
+++ b/pjecz_casiopea_api_key/routers/cit_citas.py
@@ -25,7 +25,7 @@ from ..models.cit_oficinas_servicios import CitOficinaServicio
 from ..models.cit_servicios import CitServicio
 from ..models.oficinas import Oficina
 from ..models.permisos import Permiso
-from ..schemas.cit_citas import CitCitaIn, CitCitaOut, OneCitCitaOut
+from ..schemas.cit_citas import CitCitaIn, CitCitaOut, OneCitCitaOut, CitCitaConfirmadaOut, OneCitCitaConfirmadaOut
 from .cit_dias_disponibles import listar_dias_disponibles
 from .cit_horas_disponibles import listar_horas_disponibles
 from ..services.sendmail import MyRequestError, Email, PlantillaCitaCancelada, PlantillaCitaCreada
@@ -531,3 +531,41 @@ async def paginado(
 
     # Entregar
     return paginate(consulta.filter(CitCita.estatus == "A").order_by(CitCita.id.desc()))
+
+
+@cit_citas.patch("/confirmar_cita", response_model=OneCitCitaConfirmadaOut)
+async def confirmar_cita(
+    current_user: Annotated[UsuarioInDB, Depends(get_current_active_user)],
+    database: Annotated[Session, Depends(get_db)],
+    cit_cita_codigo_barras: str,
+):
+    """Detalle de una cita a partir de su código de barras"""
+    if current_user.permissions.get("CIT CITAS", 0) < Permiso.VER:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    cit_cita = database.query(CitCita).filter_by(codigo_barras=cit_cita_codigo_barras).first()
+    if not cit_cita:
+        return OneCitCitaConfirmadaOut(success=False, message="No existe esa cita")
+    if cit_cita.estatus != "A":
+        return OneCitCitaConfirmadaOut(success=False, message="No está habilitada esa cita")
+    if cit_cita.estado != "PENDIENTE" and cit_cita.estado != "ASISTIO":
+        return OneCitCitaConfirmadaOut(success=False, message="Esta cita no está en un estado PENDIENTE")
+    
+    # TODO: Cambiar asistencia
+    # TODO: Crear Turno
+
+    # Formar CitCitaConfirmadaOut
+    cit_cita_confirmada = CitCitaConfirmadaOut(
+        id=cit_cita.id,
+        cit_cliente_nombre=cit_cita.cit_cliente.nombre,
+        cit_cliente_telefono=cit_cita.cit_cliente.telefono,
+        cit_cliente_email=cit_cita.cit_cliente.email,
+        oficina_clave=cit_cita.oficina.clave,
+        oficina_descripcion_corta=cit_cita.oficina.descripcion_corta,
+        cit_servicio_clave=cit_cita.cit_servicio.clave,
+        cit_servicio_descripcion=cit_cita.cit_servicio.descripcion,
+        fecha=cit_cita.inicio.date(),
+        hora_inicio=cit_cita.inicio.strftime("%I:%M %p").lower(),
+        notas=cit_cita.notas,
+        turno_codigo="OCP-002", #cit_cita.turno,
+    )
+    return OneCitCitaConfirmadaOut(success=True, message=f"Cita confirmada de {cit_cita.id}", data=CitCitaConfirmadaOut.model_validate(cit_cita_confirmada))

--- a/pjecz_casiopea_api_key/schemas/cit_citas.py
+++ b/pjecz_casiopea_api_key/schemas/cit_citas.py
@@ -59,3 +59,29 @@ class OneCitCitaOut(BaseModel):
     success: bool
     message: str
     data: CitCitaOut | None = None
+
+
+class CitCitaConfirmadaOut(BaseModel):
+    """Esquema para entregar una cita confirmada"""
+
+    id: uuid.UUID
+    cit_cliente_nombre: str
+    cit_cliente_email: str | None = None
+    cit_cliente_telefono: str | None = None
+    oficina_clave: str
+    oficina_descripcion_corta: str
+    cit_servicio_clave: str
+    cit_servicio_descripcion: str
+    fecha: date
+    hora_inicio: str
+    notas: str
+    turno_codigo: str
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OneCitCitaConfirmadaOut(BaseModel):
+    """Esquema para entregar una cita confirmada"""
+
+    success: bool
+    message: str
+    data: CitCitaConfirmadaOut | None = None

--- a/pjecz_casiopea_api_key/services/turnos.py
+++ b/pjecz_casiopea_api_key/services/turnos.py
@@ -1,0 +1,127 @@
+"""
+Servicio para conectar con la API del sistema de turnos
+"""
+
+import json
+import requests
+from requests.exceptions import RequestException
+from json.decoder import JSONDecodeError
+from typing import Tuple
+
+from pjecz_casiopea_flask.config.settings import Settings
+
+
+class MyAnyError(Exception):
+    """Base exception class"""
+
+class MyRequestError(MyAnyError):
+    """Excepción porque falló el request"""
+
+class Turnos():
+    """Turnos"""
+
+    _settings: Settings
+    _turno_id: int
+    _turno_codigo: str
+
+    def __init__(self, setting: Settings):
+        """Inicializa el servicio de turnos"""
+
+        self._settings = setting
+        self._turno_id = 0
+        self._turno_codigo = ""
+    
+    def crear_turno(self, payload_json: json) -> Tuple[bool, str]:
+        """
+        Crea un nuevo turno en el sistema de turnos con el tipo cita.
+        :return ID del turno y el código del turno generado.
+        """
+
+        url = f"{self._settings.TURNOS_API_KEY_URL}/crear_turno"
+        headers = {
+            "X-API-KEY": self._settings.TURNOS_API_KEY,
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = requests.post(url, headers=headers, data=payload_json, timeout=5)
+            response.raise_for_status()
+
+            try:
+                data = response.json()
+                if "success" in data and "message" in data:
+                    self._turno_id = data["data"]["turno_id"];
+                    self._turno_codigo = f'{data["data"]["unidad"]["clave"]}-{data["data"]["turno_numero"]}'
+                    return data["success"], data["message"]
+                return False, "Respuesta JSON inválida desde el servidor de turnos."
+
+            except JSONDecodeError:
+                return False, "No se pudo decodificar la respuesta JSON del servidor de turnos."
+
+        except RequestException as e:
+            return False, f"Error de conexión con el sistema de turnos: {e}"
+        except Exception as e:
+            return False, f"Ocurrió un error inesperado: {e}"
+
+    def get_turno_id(self) -> int:
+        """Entrega el ID del turno generado"""
+        return self._turno_id
+    
+    def get_turno_codigo(self) -> int:
+        """Entrega el Código del turno generado"""
+        return self._turno_codigo
+    
+    def test_conexion(self) -> Tuple[bool, str]:
+        """
+        Prueba de conexión con el sistema de turnos
+        :return Éxito o fallo y mensaje de respuesta.
+        """
+
+        url = f"{self._settings.TURNOS_API_KEY_URL}/test_conexion"
+        headers = {"X-API-KEY": self._settings.TURNOS_API_KEY}
+
+        try:
+            response = requests.get(url, headers=headers, timeout=5)
+            response.raise_for_status()  # Lanza una excepción para códigos de error HTTP (4xx o 5xx)
+
+            try:
+                data = response.json()
+                if "success" in data and "message" in data:
+                    return data["success"], data["message"]
+                return False, "Respuesta JSON inválida desde el servidor de turnos."
+
+            except JSONDecodeError:
+                return False, "No se pudo decodificar la respuesta JSON del servidor de turnos."
+
+        except RequestException as e:
+            return False, f"Error de conexión con el sistema de turnos: {e}"
+
+        except Exception as e:
+            return False, f"Ocurrió un error inesperado: {e}"
+    
+    def test_crear_turno(self, payload_json_file: json) -> Tuple[bool, str]:
+        """
+        Prueba para crear un turno en el sistema de turnos
+        :return Éxito o fallo y mensaje de respuesta.
+        """
+
+        url = f"{self._settings.TURNOS_API_KEY_URL}/test_crear_turno"
+        headers = {"X-API-KEY": self._settings.TURNOS_API_KEY}
+
+        try:
+            response = requests.post(url, headers=headers, json=payload_json_file, timeout=5)
+            response.raise_for_status()
+
+            try:
+                data = response.json()
+                if "success" in data and "message" in data:
+                    return data["success"], data["message"]
+                return False, "Respuesta JSON inválida desde el servidor de turnos."
+
+            except JSONDecodeError:
+                return False, "No se pudo decodificar la respuesta JSON del servidor de turnos."
+
+        except RequestException as e:
+            return False, f"Error de conexión con el sistema de turnos: {e}"
+        except Exception as e:
+            return False, f"Ocurrió un error inesperado: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pjecz-casiopea-api-key"
-version = "1.4.2"
+version = "1.5.0"
 description = "API con autentificación APi-Key para comunicación con el sistema de gestión SAJI."
 authors = [
     "Guillermo Valdes <guillermo.valdes@pjecz.gob.mx>",


### PR DESCRIPTION
### ✨ Mejoras

- Nuevo _endpoint_ `confirmar_cita`. Al recibir el número de código de asistencia, se marca la asistencia y se genera un turno en el sistema de turnos, y se regresa toda esa información como resultado de la petición. Si ya existe la asistencia y el turno, solo regresar la información.